### PR TITLE
Change market cycle start to match Vistani Market

### DIFF
--- a/tattooGenerator.py
+++ b/tattooGenerator.py
@@ -791,7 +791,7 @@ def main():
     TextWrapping = True
     WRAP_WIDTH_DEFAULT = 29
     POSIX_DAY_IN_SECONDS = 60 * 60 * 24
-    MARKET_CYCLE_START_POSIX = 4 * POSIX_DAY_IN_SECONDS  # Days offset from epoch
+    MARKET_CYCLE_START_POSIX = 0 * POSIX_DAY_IN_SECONDS  # Days offset from epoch
     POSTING_HOUR_DEFAULT = 0  # Hana Den posting time
     DAYS_IN_CYCLE_DEFAULT = 3  # Hana Den market cycle length
     DAYS_TO_ADD_DEFAULT = 3  # Number of days in the future for discord time code


### PR DESCRIPTION
The intent is that Tattoo Parlor and Vistani Market both refresh themselves at exactly the same times going forward - I missed this on my previous change.